### PR TITLE
Add SPI support for WS2801

### DIFF
--- a/include/LedManager.h
+++ b/include/LedManager.h
@@ -42,6 +42,8 @@ public:
 #else
     NeoPixelBus<NeoRgbFeature, Neo800KbpsMethod> *ledsDma = NULL; // Hardware DMA, GPIO3, no serial read, yes serial write
     NeoPixelBus<NeoRgbwFeature, NeoSk6812Method> *ledsDmaRgbw = NULL; // Hardware DMA, GPIO3, no serial read, yes serial write
+
+    NeoPixelBus<NeoRgbFeature, Ws2801Method> *ledsSpi = NULL; // SPI, GPIO4 (CLK), GPIO2 (DATA), yes serial read/write
     NeoPixelBus<NeoRgbFeature, NeoEsp8266Uart1800KbpsMethod> *ledsUart = NULL; // Hardware UART, GPIO2, yes serial read/write
     NeoPixelBus<NeoRgbwFeature, NeoEsp8266Uart1Sk6812Method> *ledsUartRgbw = NULL; // Hardware UART, GPIO2, yes serial read/write
     NeoPixelBus<NeoRgbFeature, NeoEsp8266BitBangWs2812xMethod> *ledsStandard = NULL; // No hardware, ALL GPIO, yes serial read/write
@@ -88,6 +90,8 @@ public:
     void initStandard();
 
     void initStandardRgbw();
+
+    void initSpi();
 
     void initUart();
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -103,7 +103,12 @@ build_flags =
 	'-D TARGET_GLOWWORMLUCIFERINLIGHT'
 	${common_env_data.common_build_flags}
 
-
+[env:glowwormluciferinlight_spi_esp8266]
+extends = env:glowwormluciferinlight_esp8266
+build_flags =
+	'-D TARGET_GLOWWORMLUCIFERINLIGHT'
+	'-D RGB_SPI'
+	${common_env_data.common_build_flags}
 
 [env:glowwormluciferinfull_esp32]
 platform = ${common_env_data.platform_esp32}


### PR DESCRIPTION
To avoid messing with PC host application there is no additional color mode, it replaces the RGB/UART mode. Therefore, SPI support has to be activated via RGB_SPI directive.
See env:glowwormluciferinlight_spi_esp8266 in platformio.ini.

Uses GPIO2 as DATA and also GPIO4 as CLK.