### PR TITLE
Track the floating esp-web-tools@10 tag

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -27,7 +27,7 @@
         // https://unpkg.com/tasmota-esp-web-tools/dist/web/install-button.js?module
         // https://unpkg.com/esp-web-tools@8.0.6/dist/web/install-button.js?module
         import(
-            "https://unpkg.com/esp-web-tools@10.2.1/dist/web/install-button.js?module"
+            "https://unpkg.com/esp-web-tools@10/dist/web/install-button.js?module"
             );
         window.addEventListener("load", function (event) {
             try {


### PR DESCRIPTION
`docs/index.html` pins `esp-web-tools@10.2.1`. This switches it to the floating `@10` tag so the installer follows v10 patch releases automatically (currently 10.4.0). The beta pages are left alone since they load the Tasmota fork.

The gain since 10.2.1 is mostly around Improv Wi-Fi, in [10.3.0](https://github.com/esphome/esp-web-tools/releases/tag/10.3.0): the network picker keeps scanning while the form is shown and merges results, each network shows signal strength, RSSI and whether it is secured, the strongest one is preselected, a device reporting the Improv *stopped* state now says so instead of showing a form that cannot succeed, and Firefox is recognized as a supported WebSerial browser. [10.4.0](https://github.com/esphome/esp-web-tools/releases/tag/10.4.0) fixes a scan race and default-selection bug in that picker.

One thing you may want to check while you are here: 10.3.0 also updated esptool-js to 0.6.0, which may affect the Lolin ESP32-S2 problem you reported in esphome/esp-web-tools#515 (you last tested on 10.1.1). If it still fails on that board, a note on the issue with the version you tested would help.